### PR TITLE
changed routes/add page for uniform reservoir names

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -43,8 +43,8 @@ export default {
     drawer: null,
     selectedItem: 1,
     items: [
-      { title: "Muscoot", icon: "mdi-map", link: "/muscoot" },
-      { title: "Croton", icon: "mdi-map", link: "/croton" },
+      { title: "Muscoot", icon: "mdi-map", link: "/Muscoot" },
+      { title: "Croton", icon: "mdi-map", link: "/Croton" },
       { title: "Record Fish", icon: "mdi-note-plus", link: "/add-record" },
     ],
     homeLink: "/",

--- a/client/src/views/AddRecord.vue
+++ b/client/src/views/AddRecord.vue
@@ -29,12 +29,13 @@
               prepend-icon="mdi-scale"
               :rules="rules"
             ></v-text-field>
-            <v-text-field
+            <v-select
               label="Reservoir"
+              :items="reservoirs"
               v-model="record.reservoir"
               prepend-icon="mdi-map"
               :rules="rules"
-            ></v-text-field>
+            ></v-select>
             <v-file-input
               @change="selectFile"
               :rules="rules"
@@ -72,7 +73,9 @@ export default {
         image: "",
       },
       image: "",
+      reservoirs:[ "Muscoot", "Croton"] 
     };
+
   },
   methods: {
     selectFile(file) {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -34,12 +34,12 @@ export default {
         {
           name: "Muscoot",
           image: muscootImage,
-          link: "/muscoot",
+          link: "/Muscoot",
         },
         {
           name: "Croton",
           image: crotonImage,
-          link: "/croton",
+          link: "/Croton",
         },
       ],
     };


### PR DESCRIPTION
updated all the routes/links to use capital letters in the reservoir name and added a dropdown to the "Record Fish" page so all records *should* start with the a capital letter so it doesnt fall out of the logic.